### PR TITLE
KVIRT-115 : Adds finalizer to cleanup ovs bridge from host nodes

### DIFF
--- a/hostplumber/pkg/utils/ovs/ovs.go
+++ b/hostplumber/pkg/utils/ovs/ovs.go
@@ -1,0 +1,40 @@
+package ovs
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func GetOvsBrList() ([]string, error) {
+
+	out, err := exec.Command("ovs-vsctl", "list-br").Output()
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	op := string(out[:])
+	output := strings.TrimSuffix(op, "\n")
+	var brList []string = strings.Split(output, "\n")
+	return brList, nil
+}
+
+func GetOvsBrPort(brName string) (string, error) {
+
+	out, err := exec.Command("ovs-vsctl", "list-ports", brName).Output()
+	if err != nil {
+		return "", err
+	}
+	if len(out) == 0 {
+		return "", nil
+	}
+	op := string(out[:])
+	port := strings.TrimSuffix(op, "\n")
+	return port, nil
+}
+
+func DeleteOvsBr(brName string) error {
+	err := exec.Command("ovs-vsctl", "del-br", brName).Run()
+	return err
+}


### PR DESCRIPTION
Delete the bridge in ovsConfigList for kubectl delete.
It adds a finalizer for the hostnetworktemplate if it has ovsConfig present in the template.
In delete flow checks for the finalizer and deletes the ovs-bridges before removing the finalizer to allow hostnetworktemplate deletion.


Tested with 2 hostnetworktemplate.