### PR TITLE
[KVIRT-201] Add Kubemacpool installation to DHCPController plugin

### DIFF
--- a/api/v1/networkplugins_types.go
+++ b/api/v1/networkplugins_types.go
@@ -85,8 +85,11 @@ type Sriov struct {
 }
 
 type DhcpController struct {
-	ImagePullPolicy     string `json:"imagePullPolicy,omitempty"`
-	DhcpControllerImage string `json:"DHCPControllerImage,omitempty"`
+	KubemacpoolNamespace  string `json:"kubemacpoolnamespace,omitempty"`
+	ImagePullPolicy       string `json:"imagePullPolicy,omitempty"`
+	DhcpControllerImage   string `json:"DHCPControllerImage,omitempty"`
+	KubemacpoolRangeStart string `json:"kubemacpoolRangeStart,omitempty"`
+	KubemacpoolRangeEnd   string `json:"kubemacpoolRangeEnd,omitempty"`
 }
 
 // NetworkPluginsStatus defines the observed state of NetworkPlugins

--- a/config/crd/bases/plumber.k8s.pf9.io_networkplugins.yaml
+++ b/config/crd/bases/plumber.k8s.pf9.io_networkplugins.yaml
@@ -43,6 +43,12 @@ spec:
                         type: string
                       imagePullPolicy:
                         type: string
+                      kubemacpoolRangeEnd:
+                        type: string
+                      kubemacpoolRangeStart:
+                        type: string
+                      kubemacpoolnamespace:
+                        type: string
                     type: object
                   hostPlumber:
                     properties:

--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -48,7 +48,8 @@ import (
 )
 
 const (
-	DefaultNamespace        = "default"
+	DefaultNamespace        = "luigi-system"
+	KubemacpoolNamespace    = "dhcp-controller-system"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2573338"
 	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-6"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2571007"
@@ -57,7 +58,10 @@ const (
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.26.2"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.26.2"
 	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.4.1"
-	DhcpControllerImage     = "docker.io/platform9/pf9-dhcp-controller:v0.1"
+	DhcpControllerImage     = "docker.io/platform9/pf9-dhcp-controller:v1.0"
+	KubemacpoolImage        = "quay.io/kubevirt/kubemacpool:latest"
+	KubemacpoolRangeStart   = "02:55:43:00:00:00"
+	KubemacpoolRangeEnd     = "02:55:43:FF:FF:FF"
 	KubeRbacProxyImage      = "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
 	NfdImage                = "docker.io/platform9/node-feature-discovery:v0.11.3-pmk-2575337"
 	TemplateDir             = "/etc/plugin_templates/"
@@ -245,7 +249,26 @@ func (dhcpControllerConfig *DhcpControllerT) WriteConfigToTemplate(outputDir, re
 		config["DhcpControllerImage"] = ReplaceContainerRegistry(DhcpControllerImage, registry)
 	}
 
+	if dhcpControllerConfig.KubemacpoolNamespace != "" {
+		config["KubemacpoolNamespace"] = dhcpControllerConfig.KubemacpoolNamespace
+	} else {
+		config["KubemacpoolNamespace"] = KubemacpoolNamespace
+	}
+
+	if dhcpControllerConfig.KubemacpoolRangeStart != "" {
+		config["KubemacpoolRangeStart"] = dhcpControllerConfig.KubemacpoolRangeStart
+	} else {
+		config["KubemacpoolRangeStart"] = KubemacpoolRangeStart
+	}
+
+	if dhcpControllerConfig.KubemacpoolRangeEnd != "" {
+		config["KubemacpoolRangeEnd"] = dhcpControllerConfig.KubemacpoolRangeEnd
+	} else {
+		config["KubemacpoolRangeEnd"] = KubemacpoolRangeEnd
+	}
+
 	config["KubeRbacProxyImage"] = ReplaceContainerRegistry(KubeRbacProxyImage, registry)
+	config["KubemacpoolImage"] = ReplaceContainerRegistry(KubemacpoolImage, registry)
 
 	t, err := template.ParseFiles(filepath.Join(TemplateDir, "dhcpcontroller", "dhcpcontroller.yaml"))
 	if err != nil {

--- a/plugin_templates/dhcpcontroller/dhcpcontroller.yaml
+++ b/plugin_templates/dhcpcontroller/dhcpcontroller.yaml
@@ -690,3 +690,463 @@ spec:
   selector:
     control-plane: controller-manager
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: mac-controller-manager
+    pod-security.kubernetes.io/enforce: restricted
+  name: {{ .KubemacpoolNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kubemacpool-manager-role
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - list
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kubemacpool-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubemacpool-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .KubemacpoolNamespace }}
+---
+apiVersion: v1
+data:
+  RANGE_END: {{ .KubemacpoolRangeEnd }}
+  RANGE_START: {{ .KubemacpoolRangeStart }}
+kind: ConfigMap
+metadata:
+  labels:
+    control-plane: mac-controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kubemacpool-mac-range-config
+  namespace: {{ .KubemacpoolNamespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubemacpool-service
+  namespace: {{ .KubemacpoolNamespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 8000
+  publishNotReadyAddresses: true
+  selector:
+    control-plane: mac-controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: cert-manager
+    controller-tools.k8s.io: "1.0"
+  name: kubemacpool-cert-manager
+  namespace: {{ .KubemacpoolNamespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: cert-manager
+      controller-tools.k8s.io: "1.0"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: kubemacpool
+        control-plane: cert-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - args:
+        - --v=production
+        command:
+        - /manager
+        env:
+        - name: RUN_CERT_MANAGER
+          value: ""
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: COMPONENT
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: PART_OF
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/part-of']
+        - name: VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
+        - name: MANAGED_BY
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/managed-by']
+        - name: CA_ROTATE_INTERVAL
+          value: 8760h0m0s
+        - name: CA_OVERLAP_INTERVAL
+          value: 24h0m0s
+        - name: CERT_ROTATE_INTERVAL
+          value: 4380h0m0s
+        - name: CERT_OVERLAP_INTERVAL
+          value: 24h0m0s
+        image: {{ .KubemacpoolImage }}
+        imagePullPolicy: {{ .ImagePullPolicy }}
+        name: manager
+        resources:
+          requests:
+            cpu: 30m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      priorityClassName: system-cluster-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: mac-controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kubemacpool-mac-controller-manager
+  namespace: {{ .KubemacpoolNamespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: mac-controller-manager
+      controller-tools.k8s.io: "1.0"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        description: KubeMacPool manages MAC allocation to Pods and VMs
+      labels:
+        app: kubemacpool
+        control-plane: mac-controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: control-plane
+                  operator: In
+                  values:
+                  - mac-controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      containers:
+      - args:
+        - --v=production
+        - --wait-time=300
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: RANGE_START
+          valueFrom:
+            configMapKeyRef:
+              key: RANGE_START
+              name: kubemacpool-mac-range-config
+        - name: RANGE_END
+          valueFrom:
+            configMapKeyRef:
+              key: RANGE_END
+              name: kubemacpool-mac-range-config
+        - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
+          value: v1
+        image: {{ .KubemacpoolImage }}
+        imagePullPolicy: {{ .ImagePullPolicy }}
+        name: manager
+        ports:
+        - containerPort: 8000
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: Content-Type
+              value: application/json
+            path: /readyz
+            port: webhook-server
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs/
+          name: tls-key-pair
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --secure-listen-address=:8443
+        - --upstream=http://127.0.0.1:8080
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+      priorityClassName: system-cluster-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 5
+      tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 60
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 60
+      volumes:
+      - name: tls-key-pair
+        secret:
+          secretName: kubemacpool-service
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kubemacpool-mutator
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .KubemacpoolNamespace }}
+      path: /mutate-pods
+  failurePolicy: Fail
+  name: mutatepods.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: mutatepods.kubemacpool.io
+      operator: In
+      values:
+      - allocate
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: NoneOnDryRun
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: kubemacpool-service
+      namespace: {{ .KubemacpoolNamespace }}
+      path: /mutate-virtualmachines
+  failurePolicy: Fail
+  name: mutatevirtualmachines.kubemacpool.io
+  namespaceSelector:
+    matchExpressions:
+    - key: runlevel
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
+      - "1"
+    - key: mutatevirtualmachines.kubemacpool.io
+      operator: NotIn
+      values:
+      - ignore
+  rules:
+  - apiGroups:
+    - kubevirt.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - virtualmachines
+  sideEffects: NoneOnDryRun


### PR DESCRIPTION
After installation, users will have to label the namespace that kubemacpool should serve manually like so
`kubectl label namespace default mutatevirtualmachines.kubemacpool.io=allocate
`