### PR TITLE
Update ci.yml to use go-coverage-action instead of CodeCov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
         run: make test
       - name: Build
         run: make build
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./cover.out
+      - name: Go Coverage
+        uses: gwatts/go-coverage-action@v1.3.0
+


### PR DESCRIPTION
CodeCov is a 3rd party app and needs additional permissions i.e. The GitHub App from CodeCov needs authorisation from pf9 admins for each repo that uses the app (or org-wide). 
Hence use the action https://github.com/marketplace/actions/go-coverage : it uses go's built in coverage command and generates a job summary. 