### PR TITLE
k8s.gcr.io is being deprecated for the newer registry.k8s.io

### DIFF
--- a/samples/macvlan/sts.yaml
+++ b/samples/macvlan/sts.yaml
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web


### PR DESCRIPTION
[PMK-5705](https://platform9.atlassian.net/browse/PMK-5705): k8s.gcr.io redirect to registry.k8s.io

k8s.gcr.io is being deprecated and moved to the newer community maintained registry.k8s.io

[PMK-5705]: https://platform9.atlassian.net/browse/PMK-5705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ