### PR TITLE
Updating the hostplumber image

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -56,7 +56,7 @@ const (
 	OvsImage                = "docker.io/platform9/openvswitch:v2.12.0"
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.26.2"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.26.2"
-	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.4.1"
+	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.4.3"
 	DhcpControllerImage     = "docker.io/platform9/pf9-dhcp-controller:v0.1"
 	KubeRbacProxyImage      = "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
 	NfdImage                = "docker.io/platform9/node-feature-discovery:v0.11.3-pmk-2575337"


### PR DESCRIPTION
Have updated the hostplumber image, which was pushed via this TC build: https://teamcity.platform9.horse/viewLog.html?buildId=2623112&buildTypeId=Pf9project_Platform9ComponentsForKubernetes_LuigiPlugins&tab=buildLog&_focus=1348#_state=1137