### PR TITLE
[0.3] AIR-928 Updating hostplumber image for resolving security vulnerabilities for hostplumber

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -54,7 +54,7 @@ const (
 	OvsImage                = "docker.io/platform9/openvswitch:v2.12.0"
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.16.2"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.16.2"
-	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.3"
+	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.3-pmk-2632584"
 	KubeRbacProxyImage      = "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
 	NfdImage                = "docker.io/platform9/node-feature-discovery:v0.6.0-pmk-1"
 	TemplateDir             = "/etc/plugin_templates/"


### PR DESCRIPTION
## ISSUE(S):
[AIR-928](https://platform9.atlassian.net/browse/AIR-767)

## SUMMARY:
Updated luigi-plugins to use the new hostplumber image. Running a trivy scan on it shows that it has no vulnerabilities:
```
trivy image -s CRITICAL,HIGH docker.io/platform9/hostplumber:v0.3-pmk-2632584
2023-04-19T18:41:16.651+0530	INFO	Need to update DB
2023-04-19T18:41:16.651+0530	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2023-04-19T18:41:16.651+0530	INFO	Downloading DB...
36.64 MiB / 36.64 MiB [---------------------------------------------------------------------------------------------------------] 100.00% 3.86 MiB p/s 9.7s
2023-04-19T18:41:28.522+0530	INFO	Vulnerability scanning is enabled
2023-04-19T18:41:28.523+0530	INFO	Secret scanning is enabled
2023-04-19T18:41:28.523+0530	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-04-19T18:41:28.523+0530	INFO	Please see also https://aquasecurity.github.io/trivy/v0.37/docs/secret/scanning/#recommendation for faster secret detection
2023-04-19T18:41:36.463+0530	INFO	Detected OS: alpine
2023-04-19T18:41:36.463+0530	INFO	Detecting Alpine vulnerabilities...
2023-04-19T18:41:36.465+0530	INFO	Number of language-specific files: 1
2023-04-19T18:41:36.465+0530	INFO	Detecting gobinary vulnerabilities...

docker.io/platform9/hostplumber:v0.3-pmk-2632584 (alpine 3.17.3)

Total: 0 (HIGH: 0, CRITICAL: 0)
```

[AIR-928]: https://platform9.atlassian.net/browse/AIR-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ