### PR TITLE
Security upgrade in whereabouts and sriov images

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -48,9 +48,9 @@ import (
 const (
 	DefaultNamespace        = "default"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-1"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.8"
-	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-1"
-	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-1"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.11"
+	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2633072"
+	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2633887"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.12.0"
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.16.2"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.16.2"


### PR DESCRIPTION
Eliminated the trivy vulns in whereabouts and sriov images and update luigi v0.3 with new images.

Tested the new imges out by replacing the images with the updated ones in pods and the pods are working fine after that

<img width="754" alt="image" src="https://user-images.githubusercontent.com/65030629/233123579-3feccb17-f78d-455e-8206-b10e6f86a912.png">
