### PR TITLE
#AIR-908 Updating kube-rbac-proxy image as a part of LTS1 security fixes

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -55,7 +55,7 @@ const (
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.16.2"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.16.2"
 	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.3-pmk-2632584"
-	KubeRbacProxyImage      = "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
+	KubeRbacProxyImage      = "platform9/kube-rbac-proxy:v0.8.0-pmk-2624525"
 	NfdImage                = "docker.io/platform9/node-feature-discovery:v0.6.0-pmk-1"
 	TemplateDir             = "/etc/plugin_templates/"
 	CreateDir               = TemplateDir + "create/"

--- a/samples/luigi-plugins-operator.yaml
+++ b/samples/luigi-plugins-operator.yaml
@@ -301,7 +301,9 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - --tls-min-version=VersionTLS12
+        image: platform9/kube-rbac-proxy:v0.8.0-pmk-2624525
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
#### Update kube-rbac-proxy to a new image with no vulnerabilities.
#### Add secure tls cipher suites and min-tls-version as requested by Mavenir as a part of this: https://platform9.atlassian.net/browse/AIR-987