### PR TITLE
AIR-927 Updating node-feature-discovery image 

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -56,7 +56,7 @@ const (
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.16.2"
 	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.3-pmk-2632584"
 	KubeRbacProxyImage      = "platform9/kube-rbac-proxy:v0.8.0-pmk-2624525"
-	NfdImage                = "docker.io/platform9/node-feature-discovery:v0.6.0-pmk-1"
+	NfdImage                = "docker.io/platform9/node-feature-discovery:v0.11.3-pmk-2636824"
 	TemplateDir             = "/etc/plugin_templates/"
 	CreateDir               = TemplateDir + "create/"
 	DeleteDir               = TemplateDir + "delete/"


### PR DESCRIPTION
## ISSUE(S):
[AIR-927](https://platform9.atlassian.net/browse/AIR-927)

## SUMMARY:
Upgraded the go packages and updated the GRPC_HEALTH_PROBE_VERSION version to resolve vulnerabilities as a part of this PR: https://github.com/platform9/node-feature-discovery/pull/1
TC build: https://teamcity.platform9.horse/viewLog.html?buildId=2636824&buildTypeId=Pf9project_Platform9ComponentsForKubernetes_NodeFeatureDiscovery&tab=buildLog&_focus=735#_state=
Trivy scan of this nfd image:
```
trivy image -s HIGH,CRITICAL docker.io/platform9/node-feature-discovery:v0.11.3-pmk-2636824
2023-04-21T06:17:30.342Z	INFO	Vulnerability scanning is enabled
2023-04-21T06:17:30.342Z	INFO	Secret scanning is enabled
2023-04-21T06:17:30.342Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-04-21T06:17:30.342Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.37/docs/secret/scanning/#recommendation for faster secret detection
2023-04-21T06:17:31.113Z	INFO	Detected OS: debian
2023-04-21T06:17:31.113Z	INFO	Detecting Debian vulnerabilities...
2023-04-21T06:17:31.122Z	INFO	Number of language-specific files: 4
2023-04-21T06:17:31.122Z	INFO	Detecting gobinary vulnerabilities...

docker.io/platform9/node-feature-discovery:v0.11.3-pmk-2636178 (debian 11.6)

Total: 2 (HIGH: 2, CRITICAL: 0)

┌───────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│  Library  │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ libssl1.1 │ CVE-2023-0464 │ HIGH     │ 1.1.1n-0+deb11u4  │               │ Denial of service by excessive resource usage in verifying │
│           │               │          │                   │               │ X509 policy constraints...                                 │
│           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                  │
├───────────┤               │          │                   ├───────────────┤                                                            │
│ openssl   │               │          │                   │               │                                                            │
│           │               │          │                   │               │                                                            │
│           │               │          │                   │               │                                                            │
└───────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```
## TESTING DONE:

#### Manual

Tested the new image (with no CRITICAL, 2 HIGH vulns) on 1.20 cluster, nfd-master and nfd-worker pods came up fine,
`nfd-master` events:
```
Events:
  Type    Reason          Age   From               Message
  ----    ------          ----  ----               -------
  Normal  Scheduled       51s   default-scheduler  Successfully assigned node-feature-discovery/nfd-master-7d854b87d-dwzhb to 10.128.144.221
  Normal  AddedInterface  49s   multus             Add eth0 [10.20.224.22/32] from k8s-pod-network
  Normal  Pulled          49s   kubelet            Container image "docker.io/platform9/node-feature-discovery:v0.11.3-pmk-2636178" already present on machine
  Normal  Created         48s   kubelet            Created container nfd-master
  Normal  Started         48s   kubelet            Started container nfd-master
```
`nfd-worker` events:
```
Events:
  Type    Reason          Age    From               Message
  ----    ------          ----   ----               -------
  Normal  Scheduled       5m29s  default-scheduler  Successfully assigned node-feature-discovery/nfd-worker-5hcst to 10.128.144.221
  Normal  AddedInterface  5m28s  multus             Add eth0 [10.20.224.20/32] from k8s-pod-network
  Normal  Pulled          5m28s  kubelet            Container image "docker.io/platform9/node-feature-discovery:v0.11.3-pmk-2636178" already present on machine
  Normal  Created         5m28s  kubelet            Created container nfd-worker
  Normal  Started         5m28s  kubelet            Started container nfd-worker
```

`nfd-master` logs:
```
 kubectl logs nfd-master-7d854b87d-dwzhb -n node-feature-discovery
I0421 06:07:47.578786       1 nfd-master.go:170] Node Feature Discovery Master v0.11.3
I0421 06:07:47.579000       1 nfd-master.go:174] NodeName: "10.128.144.221"
I0421 06:07:47.579011       1 nfd-master.go:185] starting nfd LabelRule controller
I0421 06:07:47.606888       1 nfd-master.go:226] gRPC server serving on port: 8080
I0421 06:07:52.637297       1 nfd-master.go:423] received labeling request for node "10.128.144.221"
I0421 06:08:52.691910       1 nfd-master.go:423] received labeling request for node "10.128.144.221"
```
`nfd-worker` logs:
```
kubectl logs nfd-worker-5hcst  -n node-feature-discovery
W0421 06:07:52.577441       1 main.go:91] -sleep-interval is deprecated, use 'core.sleepInterval' option in the config file, instead
I0421 06:07:52.577610       1 nfd-worker.go:155] Node Feature Discovery Worker v0.11.3
I0421 06:07:52.577621       1 nfd-worker.go:156] NodeName: '10.128.144.221'
I0421 06:07:52.578307       1 nfd-worker.go:423] configuration file "/etc/kubernetes/node-feature-discovery/nfd-worker.conf" parsed
I0421 06:07:52.578422       1 nfd-worker.go:461] worker (re-)configuration successfully completed
I0421 06:07:52.578507       1 base.go:127] connecting to nfd-master at nfd-master:8080 ...
I0421 06:07:52.578645       1 component.go:36] [core]parsed scheme: ""
I0421 06:07:52.578666       1 component.go:36] [core]scheme "" not registered, fallback to default scheme
I0421 06:07:52.578745       1 component.go:36] [core]ccResolverWrapper: sending update to cc: {[{nfd-master:8080  <nil> 0 <nil>}] <nil> <nil>}
I0421 06:07:52.578773       1 component.go:36] [core]ClientConn switching balancer to "pick_first"
I0421 06:07:52.578782       1 component.go:36] [core]Channel switches to new LB policy "pick_first"
I0421 06:07:52.578867       1 component.go:36] [core]Subchannel Connectivity change to CONNECTING
I0421 06:07:52.578975       1 component.go:36] [core]Subchannel picks a new address "nfd-master:8080" to connect
I0421 06:07:52.580354       1 component.go:36] [core]Channel Connectivity change to CONNECTING
I0421 06:07:52.596731       1 component.go:36] [core]Subchannel Connectivity change to READY
I0421 06:07:52.596786       1 component.go:36] [core]Channel Connectivity change to READY
E0421 06:07:52.612213       1 network.go:143] failed to read net iface attribute speed: read /host-sys/class/net/eth0/speed: invalid argument
I0421 06:07:52.619001       1 nfd-worker.go:472] starting feature discovery...
I0421 06:07:52.619413       1 nfd-worker.go:484] feature discovery completed
I0421 06:07:52.619445       1 nfd-worker.go:565] sending labeling request to nfd-master
E0421 06:08:52.663669       1 network.go:143] failed to read net iface attribute speed: read /host-sys/class/net/eth0/speed: invalid argument
I0421 06:08:52.670169       1 nfd-worker.go:472] starting feature discovery...
I0421 06:08:52.670477       1 nfd-worker.go:484] feature discovery completed
I0421 06:08:52.670517       1 nfd-worker.go:565] sending labeling request to nfd-master
E0421 06:09:52.732203       1 network.go:143] failed to read net iface attribute speed: read /host-sys/class/net/eth0/speed: invalid argument
I0421 06:09:52.737802       1 nfd-worker.go:472] starting feature discovery...
I0421 06:09:52.738198       1 nfd-worker.go:484] feature discovery completed
I0421 06:09:52.738230       1 nfd-worker.go:565] sending labeling request to nfd-master
E0421 06:10:52.803894       1 network.go:143] failed to read net iface attribute speed: read /host-sys/class/net/eth0/speed: invalid argument
I0421 06:10:52.808580       1 nfd-worker.go:472] starting feature discovery...
I0421 06:10:52.808918       1 nfd-worker.go:484] feature discovery completed
I0421 06:10:52.808946       1 nfd-worker.go:565] sending labeling request to nfd-master
E0421 06:11:52.846797       1 network.go:143] failed to read net iface attribute speed: read /host-sys/class/net/eth0/speed: invalid argument
I0421 06:11:52.851256       1 nfd-worker.go:472] starting feature discovery...
I0421 06:11:52.851531       1 nfd-worker.go:484] feature discovery completed
I0421 06:11:52.851561       1 nfd-worker.go:565] sending labeling request to nfd-master
E0421 06:12:52.885618       1 network.go:143] failed to read net iface attribute speed: read /host-sys/class/net/eth0/speed: invalid argument
I0421 06:12:52.890223       1 nfd-worker.go:472] starting feature discovery...
I0421 06:12:52.890469       1 nfd-worker.go:484] feature discovery completed
I0421 06:12:52.890500       1 nfd-worker.go:565] sending labeling request to nfd-master
```


[AIR-927]: https://platform9.atlassian.net/browse/AIR-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ