### PR TITLE
#AIR-1013 Updating kube-rbac-proxy image

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -55,7 +55,7 @@ const (
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.16.2"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.16.2"
 	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.3-pmk-2632584"
-	KubeRbacProxyImage      = "platform9/kube-rbac-proxy:v0.8.0-pmk-2624525"
+	KubeRbacProxyImage      = "docker.io/platform9/kube-rbac-proxy:v0.8.0-pmk-2636740"
 	NfdImage                = "docker.io/platform9/node-feature-discovery:v0.11.3-pmk-2636824"
 	TemplateDir             = "/etc/plugin_templates/"
 	CreateDir               = TemplateDir + "create/"

--- a/samples/luigi-plugins-operator.yaml
+++ b/samples/luigi-plugins-operator.yaml
@@ -303,7 +303,7 @@ spec:
         - --v=10
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         - --tls-min-version=VersionTLS12
-        image: platform9/kube-rbac-proxy:v0.8.0-pmk-2624525
+        image: platform9/kube-rbac-proxy:v0.8.0-pmk-2636740
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Updating kube-rbac-proxy image to use a docker image built from the release branch.