### PR TITLE
AIR-1013 Updating LTS1 sriovdp images from release branches

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -50,7 +50,7 @@ const (
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-1"
 	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.11"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2633072"
-	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2633887"
+	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2640320"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.12.0"
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.16.2"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.16.2"


### PR DESCRIPTION
Updating LTS1 images(sriovdp) to use docker images built from the release branches.