### PR TITLE
Adding the tls cipher flags to kube-rbac-proxy container in the hostplumber pod

### DIFF
--- a/plugin_templates/pf9-hostplumber/hostplumber.yaml
+++ b/plugin_templates/pf9-hostplumber/hostplumber.yaml
@@ -480,6 +480,8 @@ spec:
         - --upstream=http://127.0.0.1:18080/
         - --logtostderr=true
         - --v=10
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - --tls-min-version=VersionTLS12
         image: {{ .KubeRbacProxyImage }}
         name: kube-rbac-proxy
         ports:


### PR DESCRIPTION
Fixes [#AIR-987](https://platform9.atlassian.net/browse/AIR-987) 