### PR TITLE
PMK-3950 Updating the whereabouts image

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -55,7 +55,7 @@ const (
 	DefaultNamespace        = "luigi-system"
 	KubemacpoolNamespace    = "dhcp-controller-system"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2644970"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-6"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-2754876"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2571007"
 	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2571186"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5-1"

--- a/v2/controllers/networkplugins_controller.go
+++ b/v2/controllers/networkplugins_controller.go
@@ -48,7 +48,7 @@ import (
 const (
 	DefaultNamespace        = "default"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2573338"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-6"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-2754876"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2571007"
 	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2571186"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.12.0"


### PR DESCRIPTION
## ISSUE(S):
[PMK-3950](https://platform9.atlassian.net/browse/PMK-3950)

## SUMMARY
Resolved vulnerabilities for whereabouts, and updating the whereabouts image in luigi (whereabouts image pushed from release branch: https://teamcity.platform9.horse/viewLog.html?buildId=2754876&buildTypeId=Pf9project_Platform9ComponentsForKubernetes_Whereabouts&tab=buildResultsDiv).

Trivy scan report:
```
docker.io/platform9/whereabouts:v0.6-pmk-2754876 (alpine 3.18.2)

Total: 0 (HIGH: 0, CRITICAL: 0)
```

## TESTING

#### Manual
Tested on 1.25 cluster, whereabouts and luigi-controller-manager pods came up fine
Luigi pod events
```
Events:
  Type    Reason          Age   From               Message
  ----    ------          ----  ----               -------
  Normal  Scheduled       47s   default-scheduler  Successfully assigned luigi-system/luigi-controller-manager-66cc4588cb-qb22k to 10.128.147.42
  Normal  AddedInterface  47s   multus             Add eth0 [10.20.20.152/32] from k8s-pod-network
  Normal  Pulled          46s   kubelet            Container image "gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0" already present on machine
  Normal  Created         46s   kubelet            Created container kube-rbac-proxy
  Normal  Started         46s   kubelet            Started container kube-rbac-proxy
  Normal  Pulling         46s   kubelet            Pulling image "platform9/luigi-plugins:private-v0.5.0-manasa-whereabouts-pmk-2752253"
  Normal  Pulled          44s   kubelet            Successfully pulled image "platform9/luigi-plugins:private-v0.5.0-manasa-whereabouts-pmk-2752253" in 2.305638041s
  Normal  Created         44s   kubelet            Created container manager
  Normal  Started         43s   kubelet            Started container manager
```

whereabouts pod events:
```

Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  30s   default-scheduler  Successfully assigned luigi-system/whereabouts-7vrww to 10.128.147.42
  Normal  Pulling    30s   kubelet            Pulling image "docker.io/platform9/whereabouts:v0.6-pmk-2750811"
  Normal  Pulled     25s   kubelet            Successfully pulled image "docker.io/platform9/whereabouts:v0.6-pmk-2750811" in 4.836948725s
  Normal  Created    25s   kubelet            Created container whereabouts
  Normal  Started    25s   kubelet            Started container whereabouts
```

Pods:
```
kubernetes-dashboard     kubernetes-dashboard-579ddcbf4d-q9lrk        1/1     Running            0               18h
luigi-system             hostplumber-controller-manager-zxwd5         2/2     Running            0               18h
luigi-system             kube-multus-ds-amd64-7fdxx                   1/1     Running            0               35s
luigi-system             luigi-controller-manager-66cc4588cb-qb22k    2/2     Running            0               66s
luigi-system             whereabouts-7vrww                            1/1     Running            0               14s
node-feature-discovery   nfd-master-bd9546c66-67t46                   1/1     Running            0               18h
```

[PMK-3950]: https://platform9.atlassian.net/browse/PMK-3950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ