### PR TITLE
[backport] PMK-6100: security fixes whereabouts image update 

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -55,7 +55,7 @@ const (
 	DefaultNamespace        = "luigi-system"
 	KubemacpoolNamespace    = "dhcp-controller-system"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2644970"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-2754876"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-2871011"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2571007"
 	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2571186"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5-1"


### PR DESCRIPTION
Backport: https://github.com/platform9/luigi/pull/107

JIRA: [PMK-6100](https://platform9.atlassian.net/browse/PMK-6100)

```bash
❯ trivy image -s CRITICAL,HIGH docker.io/platform9/whereabouts:v0.6-pmk-2871011
2023-10-05T11:32:41.719+0530	INFO	Need to update DB
2023-10-05T11:32:41.719+0530	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2023-10-05T11:32:41.719+0530	INFO	Downloading DB...
40.12 MiB / 40.12 MiB [----------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 8.40 MiB p/s 5.0s
2023-10-05T11:32:48.289+0530	INFO	Vulnerability scanning is enabled
2023-10-05T11:32:48.289+0530	INFO	Secret scanning is enabled
2023-10-05T11:32:48.289+0530	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-10-05T11:32:48.289+0530	INFO	Please see also https://aquasecurity.github.io/trivy/v0.45/docs/scanner/secret/#recommendation for faster secret detection
2023-10-05T11:32:51.434+0530	INFO	Detected OS: alpine
2023-10-05T11:32:51.434+0530	INFO	Detecting Alpine vulnerabilities...
2023-10-05T11:32:51.439+0530	INFO	Number of language-specific files: 2
2023-10-05T11:32:51.439+0530	INFO	Detecting gobinary vulnerabilities...

docker.io/platform9/whereabouts:v0.6-pmk-2871011 (alpine 3.18.4)

Total: 0 (HIGH: 0, CRITICAL: 0)
```

https://teamcity.platform9.horse/buildConfiguration/Pf9project_Platform9ComponentsForKubernetes_Whereabouts/2871011

[PMK-6100]: https://platform9.atlassian.net/browse/PMK-6100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ