### PR TITLE
Hostplumber image update v0.5.2

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -61,7 +61,7 @@ const (
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5-1"
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.28.0"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.28.0"
-	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.5.1"
+	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.5.2"
 	DhcpControllerImage     = "docker.io/platform9/pf9-dhcp-controller:v1.0"
 	KubemacpoolImage        = "quay.io/kubevirt/kubemacpool:v0.41.0"
 	KubemacpoolRangeStart   = "02:55:43:00:00:00"


### PR DESCRIPTION
Hostplumber image tag updated in luigi

```bash
(base) ➜  ~ trivy image platform9/hostplumber:v0.5.2
2023-11-07T05:47:07.317Z	INFO	Vulnerability scanning is enabled
2023-11-07T05:47:07.317Z	INFO	Secret scanning is enabled
2023-11-07T05:47:07.317Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-07T05:47:07.317Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.45/docs/scanner/secret/#recommendation for faster secret detection
2023-11-07T05:47:07.330Z	INFO	Detected OS: alpine
2023-11-07T05:47:07.330Z	INFO	Detecting Alpine vulnerabilities...
2023-11-07T05:47:07.341Z	INFO	Number of language-specific files: 2
2023-11-07T05:47:07.341Z	INFO	Detecting gobinary vulnerabilities...
2023-11-07T05:47:07.342Z	INFO	Detecting python-pkg vulnerabilities...

platform9/hostplumber:v0.5.2 (alpine 3.16.7)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```