### PR TITLE
[Backport] AIR-1268: Revert Whereabout version to v0.4.12

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -51,7 +51,7 @@ const (
 	DefaultNamespace        = "luigi-system"
 	KubemacpoolNamespace    = "dhcp-controller-system"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2644970"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.3"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.12"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2571007"
 	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2571186"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5"

--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -51,7 +51,7 @@ const (
 	DefaultNamespace        = "luigi-system"
 	KubemacpoolNamespace    = "dhcp-controller-system"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2644970"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-6"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.3"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2571007"
 	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2571186"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5"
@@ -481,11 +481,11 @@ func (ovsConfig *OvsT) WriteConfigToTemplate(outputDir, registry string) error {
 	}
 
 	if ovsConfig.DPDK != nil {
-                if ovsConfig.DPDK.LcoreMask == "" || ovsConfig.DPDK.SocketMem == "" || ovsConfig.DPDK.PmdCpuMask == "" || ovsConfig.DPDK.HugepageMemory == "" {
-                        return fmt.Errorf("LcoreMask, SocketMem, PmdCpuMask, HugepageMemory are required parameters to enable Dpdk")
-                }
-                config["DPDK"] = ovsConfig.DPDK
-        }
+		if ovsConfig.DPDK.LcoreMask == "" || ovsConfig.DPDK.SocketMem == "" || ovsConfig.DPDK.PmdCpuMask == "" || ovsConfig.DPDK.HugepageMemory == "" {
+			return fmt.Errorf("LcoreMask, SocketMem, PmdCpuMask, HugepageMemory are required parameters to enable Dpdk")
+		}
+		config["DPDK"] = ovsConfig.DPDK
+	}
 
 	// Apply the OVS DaemonSet
 	t, err := template.ParseFiles(filepath.Join(TemplateDir, "ovs", "ovs-daemons.yaml"))


### PR DESCRIPTION
Backport: https://github.com/platform9/luigi/pull/123
Jira: [AIR-1268](https://platform9.atlassian.net/browse/AIR-1268)
Reverting Whereabouts to v0.4.3 




[AIR-1268]: https://platform9.atlassian.net/browse/AIR-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ