### PR TITLE
[backport] AIR-1268: Revert Whereabout version to v0.4.12

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -55,7 +55,7 @@ const (
 	DefaultNamespace        = "luigi-system"
 	KubemacpoolNamespace    = "dhcp-controller-system"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2644970"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-2871011"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.3"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2877848"
 	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2877839"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5-2"

--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -55,7 +55,7 @@ const (
 	DefaultNamespace        = "luigi-system"
 	KubemacpoolNamespace    = "dhcp-controller-system"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2644970"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.3"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.12"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2877848"
 	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2877839"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5-2"


### PR DESCRIPTION
Backport: https://github.com/platform9/luigi/pull/123
Jira: [AIR-1268](https://platform9.atlassian.net/browse/AIR-1268)
Reverting Whereabouts to v0.4.3 




[AIR-1268]: https://platform9.atlassian.net/browse/AIR-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ