### PR TITLE
Upgraded whereabouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ spec:
     multus: {}
     whereabouts:
       ipReconcilerSchedule: "*/1 * * * *"
-      ipReconcilerNodeSelector:
-         foo: bar
     # SRIOV actually consists of two plugins - the CNI, and the device-plugin
     # Use HostPlumber to create the actual VFs
     sriov: {}

--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -55,7 +55,7 @@ const (
 	DefaultNamespace        = "luigi-system"
 	KubemacpoolNamespace    = "dhcp-controller-system"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2644970"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.4.12"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-2871011"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2877848"
 	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2877839"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5-2"

--- a/plugin_templates/whereabouts/whereabouts.yaml
+++ b/plugin_templates/whereabouts/whereabouts.yaml
@@ -47,7 +47,40 @@ rules:
   - pods
   verbs:
   - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
   - get
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+    - network-attachment-definitions
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+    - events
+  verbs:
+  - create
+  - patch
+  - update
+  - get
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whereabouts-config
+  namespace: {{ .Namespace }}
+  annotations:
+    kubernetes.io/description: |
+      Configmap containing user customizable cronjob schedule
+data:
+  cron-expression:  "{{ .IpReconcilerSchedule }}"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -72,16 +105,25 @@ spec:
     spec:
       hostNetwork: true      
       serviceAccountName: whereabouts
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule
       containers:
       - name: whereabouts
+        command: [ "/bin/sh" ]
+        args:
+          - -c
+          - >
+            SLEEP=false /install-cni.sh &&
+            /ip-control-loop -log-level debug
         image: {{ .WhereaboutsImage }}
         imagePullPolicy: {{ .ImagePullPolicy }}
         env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         - name: WHEREABOUTS_NAMESPACE
           valueFrom:
             fieldRef:
@@ -89,10 +131,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "100Mi"
           limits:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "200Mi"
         securityContext:
           privileged: true
         volumeMounts:
@@ -100,6 +142,8 @@ spec:
           mountPath: /host/opt/cni/bin
         - name: cni-net-dir
           mountPath: /host/etc/cni/net.d
+        - name: cron-scheduler-configmap
+          mountPath: /cron-schedule
       volumes:
         - name: cnibin
           hostPath:
@@ -107,7 +151,13 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
-
+        - name: cron-scheduler-configmap
+          configMap:
+            name: "whereabouts-config"
+            defaultMode: 0744
+            items:
+            - key: "cron-expression"
+              path: "config"
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -236,57 +286,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-
----
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: ip-reconciler
-  namespace: {{ .Namespace }}
-  labels:
-    tier: node
-    app: whereabouts
-spec:
-  concurrencyPolicy: Forbid
-  schedule: "{{ .IpReconcilerSchedule }}"
-  jobTemplate:
-    spec:
-      backoffLimit: 0
-      template:
-        metadata:
-          labels:
-            app: whereabouts
-        spec:
-          {{if .NodeSelector -}} nodeSelector:
-          {{- range $label, $val := .NodeSelector}}
-              {{ $label -}} : {{ $val -}}
-          {{end}}
-          {{end -}}
-          priorityClassName: "system-node-critical"
-          containers:
-            - name: whereabouts
-              image: {{ .WhereaboutsImage }}
-              resources:
-                requests:
-                  cpu: "100m"
-                  memory: "50Mi"
-                limits:
-                  cpu: "100m"
-                  memory: "250Mi"
-              command:
-                - /ip-reconciler
-                - -kubeconfig=/host/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig
-              volumeMounts:
-                - name: cni-net-dir
-                  mountPath: /host/etc/cni/net.d
-                - mountPath: /host/var/log/pf9
-                  name: reconciler-log
-          volumes:
-            - name: cni-net-dir
-              hostPath:
-                path: /etc/cni/net.d
-            - name: reconciler-log
-              hostPath:
-                path: /var/log/pf9
-          restartPolicy: OnFailure
-


### PR DESCRIPTION
re upgrading `platform9/whereabouts:v0.6-pmk-2871011`
`ip-reconciler` is removed, in whereabouts version 6 
Reconciliation happen inside pod and can be configured with configmap 

ipReconcilerNodeSelector field in NetworkPlugins is redundant. Reconciler works within pod
However logic is not removed for backward compatibility 
### Test
<img width="935" alt="Screenshot 2024-01-08 at 11 33 07 AM" src="https://github.com/platform9/luigi/assets/35176826/34c0ba41-de3a-4ac6-a8cf-d62c9a6b6436">
