### PR TITLE
PMK-6316: Update Whereabouts to v0.6.3

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -55,7 +55,7 @@ const (
 	DefaultNamespace        = "luigi-system"
 	KubemacpoolNamespace    = "dhcp-controller-system"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2644970"
-	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-2871011"
+	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6.3"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2877848"
 	SriovDpImage            = "docker.io/platform9/sriov-network-device-plugin:v3.3.2-pmk-2877839"
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5-2"


### PR DESCRIPTION
Whereabout v0.6.3 update

## Testing
```bash

k get nodes
NAME             STATUS   ROLES    AGE   VERSION
10.149.106.142   Ready    worker   71m   v1.27.8
10.149.107.144   Ready    master   71m   v1.27.8
k apply -f samples/nad.yaml
networkattachmentdefinition.k8s.cni.cncf.io/whereabouts-conf created
k cordon 10.149.107.144
node/10.149.107.144 cordoned
k apply -f samples/deploy.yaml
deployment.apps/sampledeployment created
k get pods
NAME                               READY   STATUS              RESTARTS   AGE
sampledeployment-d985869d4-bwf2h   0/1     ContainerCreating   0          3s
sampledeployment-d985869d4-t2tpv   1/1     Running             0          3s
k describe pod sampledeployment-d985869d4-t2tpv
Name:             sampledeployment-d985869d4-t2tpv
Namespace:        default
Priority:         0
Service Account:  default
Node:             10.149.106.142/10.149.106.142
Start Time:       Wed, 14 Feb 2024 05:49:21 +0000
Labels:           app=samplepod
                  pod-template-hash=d985869d4
Annotations:      cni.projectcalico.org/containerID: 4dc2c2c2cb9bf90427eb8664acda36f9f5e8cfec01ab399e206c320fa6f4f8b1
                  cni.projectcalico.org/podIP: 10.20.234.205/32
                  cni.projectcalico.org/podIPs: 10.20.234.205/32
                  k8s.v1.cni.cncf.io/network-status:
                    [{
                        "name": "k8s-pod-network",
                        "ips": [
                            "10.20.234.205"
                        ],
                        "default": true,
                        "dns": {}
                    },{
                        "name": "default/whereabouts-conf",
                        "interface": "net1",
                        "ips": [
                            "10.128.165.32"
                        ],
                        "mac": "ce:21:d5:e0:e3:b2",
                        "dns": {}
                    }]
                  k8s.v1.cni.cncf.io/networks: whereabouts-conf
                  k8s.v1.cni.cncf.io/networks-status:
                    [{
                        "name": "k8s-pod-network",
                        "ips": [
                            "10.20.234.205"
                        ],
                        "default": true,
                        "dns": {}
                    },{
                        "name": "default/whereabouts-conf",
                        "interface": "net1",
                        "ips": [
                            "10.128.165.32"
                        ],
                        "mac": "ce:21:d5:e0:e3:b2",
                        "dns": {}
                    }]
Status:           Running
IP:               10.20.234.205
IPs:
  IP:           10.20.234.205
Controlled By:  ReplicaSet/sampledeployment-d985869d4
Containers:
  samplepod:
    Container ID:  containerd://7803f7014cc5c3c5e742969ca2c72a1c6d294d605dc82b550141b085aaa16c05
    Image:         alpine
    Image ID:      docker.io/library/alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/ash
      -c
      trap : TERM INT; sleep infinity & wait
    State:          Running
      Started:      Wed, 14 Feb 2024 05:49:23 +0000
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-smqbn (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  kube-api-access-smqbn:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 2s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 2s
Events:
  Type    Reason          Age   From               Message
  ----    ------          ----  ----               -------
  Normal  Scheduled       9s    default-scheduler  Successfully assigned default/sampledeployment-d985869d4-t2tpv to 10.149.106.142
  Normal  AddedInterface  8s    multus             Add eth0 [10.20.234.205/32] from k8s-pod-network
  Normal  AddedInterface  8s    multus             Add net1 [10.128.165.32/24] from default/whereabouts-conf
  Normal  Pulling         8s    kubelet            Pulling image "alpine"
  Normal  Pulled          7s    kubelet            Successfully pulled image "alpine" in 638.871256ms (638.890381ms including waiting)
  Normal  Created         7s    kubelet            Created container samplepod
  Normal  Started         7s    kubelet            Started container samplepod
k get pods
NAME                               READY   STATUS    RESTARTS   AGE
sampledeployment-d985869d4-bwf2h   1/1     Running   0          16s
sampledeployment-d985869d4-t2tpv   1/1     Running   0          16s
k get nodes
NAME             STATUS                     ROLES    AGE   VERSION
10.149.106.142   Ready                      worker   72m   v1.27.8
10.149.107.144   Ready,SchedulingDisabled   master   72m   v1.27.8
k uncordon 10.149.107.144
node/10.149.107.144 uncordoned
k get pods -o wide -w
NAME                               READY   STATUS    RESTARTS   AGE   IP              NODE             NOMINATED NODE   READINESS GATES
sampledeployment-d985869d4-bwf2h   1/1     Running   0          37s   10.20.234.206   10.149.106.142   <none>           <none>
sampledeployment-d985869d4-t2tpv   1/1     Running   0          37s   10.20.234.205   10.149.106.142   <none>           <none>
^C%                                                                                                                                                                                                    
k get pods -n luigi-system
NAME                                        READY   STATUS    RESTARTS   AGE
kube-multus-ds-amd64-7xffr                  1/1     Running   0          4m31s
kube-multus-ds-amd64-ghxqs                  1/1     Running   0          4m31s
luigi-controller-manager-669745cc8d-gmc8s   2/2     Running   0          7m5s
whereabouts-lr8sl                           1/1     Running   0          4m30s
whereabouts-tt8n8                           1/1     Running   0          4m30s
k get pods -n luigi-system -o wide
NAME                                        READY   STATUS    RESTARTS   AGE     IP               NODE             NOMINATED NODE   READINESS GATES
kube-multus-ds-amd64-7xffr                  1/1     Running   0          4m40s   10.149.107.144   10.149.107.144   <none>           <none>
kube-multus-ds-amd64-ghxqs                  1/1     Running   0          4m40s   10.149.106.142   10.149.106.142   <none>           <none>
luigi-controller-manager-669745cc8d-gmc8s   2/2     Running   0          7m14s   10.20.234.203    10.149.106.142   <none>           <none>
whereabouts-lr8sl                           1/1     Running   0          4m39s   10.149.106.142   10.149.106.142   <none>           <none>
whereabouts-tt8n8                           1/1     Running   0          4m39s   10.149.107.144   10.149.107.144   <none>           <none>
k logs -n luigi-system whereabouts-tt8n8
Done configuring CNI.  Sleep=false
2024-02-14T05:46:00Z [debug] Filtering pods with filter key 'spec.nodeName' and filter value '10.149.107.144'
2024-02-14T05:46:00Z [verbose] pod controller created
2024-02-14T05:46:00Z [verbose] Starting informer factories ...
2024-02-14T05:46:00Z [verbose] Informer factories started
2024-02-14T05:46:00Z [verbose] starting network controller
2024-02-14T05:46:01Z [verbose] using expression: * * * * *
2024-02-14T05:47:00Z [verbose] starting reconciler run
2024-02-14T05:47:00Z [debug] NewReconcileLooper - inferred connection data
2024-02-14T05:47:00Z [debug] listing IP pools
2024-02-14T05:47:00Z [debug] no IP addresses to cleanup
2024-02-14T05:47:00Z [verbose] reconciler success
2024-02-14T05:48:00Z [verbose] starting reconciler run
2024-02-14T05:48:00Z [debug] NewReconcileLooper - inferred connection data
2024-02-14T05:48:00Z [debug] listing IP pools
2024-02-14T05:48:00Z [debug] no IP addresses to cleanup
2024-02-14T05:48:00Z [verbose] reconciler success
2024-02-14T05:49:00Z [verbose] starting reconciler run
2024-02-14T05:49:00Z [debug] NewReconcileLooper - inferred connection data
2024-02-14T05:49:00Z [debug] listing IP pools
2024-02-14T05:49:00Z [debug] no IP addresses to cleanup
2024-02-14T05:49:00Z [verbose] reconciler success
2024-02-14T05:50:00Z [verbose] starting reconciler run
2024-02-14T05:50:00Z [debug] NewReconcileLooper - inferred connection data
2024-02-14T05:50:00Z [debug] listing IP pools
2024-02-14T05:50:00Z [debug] Added IP 10.128.165.33 for pod default/sampledeployment-d985869d4-bwf2h
2024-02-14T05:50:00Z [debug] Added IP 10.128.165.32 for pod default/sampledeployment-d985869d4-t2tpv
2024-02-14T05:50:00Z [debug] the IP reservation: IP: 10.128.165.32 is reserved for pod: default/sampledeployment-d985869d4-t2tpv
2024-02-14T05:50:00Z [debug] pod reference default/sampledeployment-d985869d4-t2tpv matches allocation; Allocation IP: 10.128.165.32; PodIPs: map[10.128.165.32:{}]
2024-02-14T05:50:00Z [debug] the IP reservation: IP: 10.128.165.33 is reserved for pod: default/sampledeployment-d985869d4-bwf2h
2024-02-14T05:50:00Z [debug] pod reference default/sampledeployment-d985869d4-bwf2h matches allocation; Allocation IP: 10.128.165.33; PodIPs: map[10.128.165.33:{}]
2024-02-14T05:50:00Z [debug] pod reference default/sampledeployment-d985869d4-t2tpv matches allocation; Allocation IP: 10.128.165.32; PodIPs: map[10.128.165.32:{}]
2024-02-14T05:50:00Z [debug] pod reference default/sampledeployment-d985869d4-bwf2h matches allocation; Allocation IP: 10.128.165.33; PodIPs: map[10.128.165.33:{}]
2024-02-14T05:50:00Z [debug] no IP addresses to cleanup
2024-02-14T05:50:00Z [verbose] reconciler success
k get nodes
NAME             STATUS   ROLES    AGE   VERSION
10.149.106.142   Ready    worker   73m   v1.27.8
10.149.107.144   Ready    master   73m   v1.27.8
k get nodes
NAME             STATUS   ROLES    AGE   VERSION
10.149.106.142   Ready    worker   74m   v1.27.8
10.149.107.144   Ready    master   74m   v1.27.8
k get nodes
NAME             STATUS   ROLES    AGE   VERSION
10.149.106.142   Ready    worker   74m   v1.27.8
10.149.107.144   Ready    master   74m   v1.27.8
k get nodes
NAME             STATUS   ROLES    AGE   VERSION
10.149.106.142   Ready    worker   74m   v1.27.8
10.149.107.144   Ready    master   74m   v1.27.8
k get pods -n luigi-system -o wide
NAME                                        READY   STATUS    RESTARTS   AGE     IP               NODE             NOMINATED NODE   READINESS GATES
kube-multus-ds-amd64-7xffr                  1/1     Running   0          6m13s   10.149.107.144   10.149.107.144   <none>           <none>
kube-multus-ds-amd64-ghxqs                  1/1     Running   0          6m13s   10.149.106.142   10.149.106.142   <none>           <none>
luigi-controller-manager-669745cc8d-gmc8s   2/2     Running   0          8m47s   10.20.234.203    10.149.106.142   <none>           <none>
whereabouts-lr8sl                           1/1     Running   0          6m12s   10.149.106.142   10.149.106.142   <none>           <none>
whereabouts-tt8n8                           1/1     Running   0          6m12s   10.149.107.144   10.149.107.144   <none>           <none>
k get nodes
NAME             STATUS   ROLES    AGE   VERSION
10.149.106.142   Ready    worker   74m   v1.27.8
10.149.107.144   Ready    master   74m   v1.27.8
k get pods -o wide -w
NAME                               READY   STATUS    RESTARTS   AGE     IP              NODE             NOMINATED NODE   READINESS GATES
sampledeployment-d985869d4-bwf2h   1/1     Running   0          2m50s   10.20.234.206   10.149.106.142   <none>           <none>
sampledeployment-d985869d4-t2tpv   1/1     Running   0          2m50s   10.20.234.205   10.149.106.142   <none>           <none>
sampledeployment-d985869d4-bwf2h   1/1     Running   0          2m52s   10.20.234.206   10.149.106.142   <none>           <none
sampledeployment-d985869d4-m2b8z   0/1     ContainerCreating   0          1s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-m2b8z   0/1     ContainerCreating   0          1s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          2s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-m2b8z   1/1     Running             0          2s      10.20.87.135    10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          3s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          3s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          4s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          4s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          5s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          5s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          6s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          6s      <none>          10.149.107.144   <none>           <none>
sampledeployment-d985869d4-76pvj   0/1     ContainerCreating   0          7s      <none>          10.149.107.144   <none>           <none>

^C%                        ```
