### PR TITLE
PMK-6377 Changing the label for hostplumber

### DIFF
--- a/hostplumber/config/manager/manager.yaml
+++ b/hostplumber/config/manager/manager.yaml
@@ -4,17 +4,17 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: hostplumber-controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: hostplumber-controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: hostplumber-controller-manager
     spec:
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/hostplumber/config/prometheus/monitor.yaml
+++ b/hostplumber/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: hostplumber-controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: hostplumber-controller-manager

--- a/hostplumber/config/rbac/auth_proxy_service.yaml
+++ b/hostplumber/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: hostplumber-controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:


### PR DESCRIPTION
**Issue:** [PMK-6377](https://platform9.atlassian.net/browse/PMK-6377)

**Summary:**  Both `Luigi` and `hostplumber` pods have the same label  as `controller-manger`. When we delete `network plugin`, it uses `controller-manger` label to pass request to `webhook`. Since both `luigi` and `hostplumber` pods have same labels, request was getting forwarded to, sometimes, `hostplumber` pod and sometimes, to the `luigi` pod, which was causing timeouts. Changing the label and selector for hostplumber. 

**Testing:** https://platform9.atlassian.net/browse/PMK-6377?focusedCommentId=98311

[PMK-6377]: https://platform9.atlassian.net/browse/PMK-6377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ