### PR TITLE
Update ENVTEST_K8S_VERSION to 1.27 and pin envtest to v0.0.0-20230216…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL=/bin/bash
 VER_LABEL=$(shell ./get-label.bash)
 IMG ?= platform9/luigi-plugins:$(VER_LABEL)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.27
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -144,7 +144,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
 
 img-test:
 	docker run --rm  -v $(SRCROOT):/luigi -w /luigi golang:1.21  bash -c "GOFLAGS=-buildvcs=false make test"

--- a/dhcp-controller/Makefile
+++ b/dhcp-controller/Makefile
@@ -5,7 +5,7 @@ IMG_TAG = v1.1
 IMG_REGISTRY ?= artifactory.platform9.horse/docker-local
 #IMG_REGISTRY = docker.io/platform9
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.1
+ENVTEST_K8S_VERSION = 1.27
 SRCROOT = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/)
 BUILD_DIR :=$(SRCROOT)/bin
 
@@ -144,4 +144,4 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e

--- a/hostplumber/Makefile
+++ b/hostplumber/Makefile
@@ -3,7 +3,7 @@ SHELL=/bin/bash
 VER_LABEL=$(shell ../get-label.bash)
 IMG ?= platform9/hostplumber:$(VER_LABEL)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.27
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -143,7 +143,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
 
 img-test:
 	docker run --rm  -v $(SRCROOT):/hostplumber -w /hostplumber golang:1.21  bash -c "make test"


### PR DESCRIPTION
…140739-c98506dc3b8e

Picked Feb 2023 version of envtest as newer one needs go 1.22 or newer

Luigi TC build passed - https://teamcity.platform9.horse/buildConfiguration/Pf9project_Platform9ComponentsForKubernetes_LuigiPlugins/3259634?buildTab=log