### PR TITLE
PMK-6377 Changing the labels for hostplumber

### DIFF
--- a/plugin_templates/pf9-hostplumber/hostplumber.yaml
+++ b/plugin_templates/pf9-hostplumber/hostplumber.yaml
@@ -477,7 +477,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: hostplumber-controller-manager
   name: hostplumber-controller-manager-metrics-service
   namespace: {{ .Namespace }}
 spec:
@@ -493,19 +493,19 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: hostplumber-controller-manager
   name: hostplumber-controller-manager
   namespace: {{ .Namespace }}
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: hostplumber-controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: hostplumber-controller-manager
     spec:
       containers:
       - args:


### PR DESCRIPTION
[PMK-6377](https://platform9.atlassian.net/browse/PMK-6377)

Summary:

Testing:
Used image with my changes: 
```
root@test-pf9-qbert-bare-os-u20-3262280-171-2:~# k describe pod -n luigi-system             luigi-controller-manager-6f84b6588-w5wbn
Name:             luigi-controller-manager-6f84b6588-w5wbn
Namespace:        luigi-system
...
Container ID:  containerd://03f75a75ffb090b5e825e9b691099b00cbcf5804a0f2782ba6452db30cda820a
    Image:         vedantjoshi84/luigi:v0.5.5-2
```

Then applied this network-plugin yaml: 
```
root@test-pf9-qbert-bare-os-u20-3262280-171-2:~# cat luigi.yaml 
apiVersion: plumber.k8s.pf9.io/v1
kind: NetworkPlugins
metadata:
 finalizers:
 - teardownPlugins
 generation: 2
 labels:
  app.kubernetes.io/instance: prod-networking
 name: networkplugins2-luigi
spec:
 # Add fields here
 #privateRegistryBase: "localhost:5100"
 plugins:
  dhcpController: {}
  ovs: {}
  hostPlumber: {}
  nodeFeatureDiscovery: {}
  multus: {}
  whereabouts: 
   namespace: default
   ipReconcilerSchedule: "* * * * *"
  #sriov: {}
  #ovs: {}
```

```
root@test-pf9-qbert-bare-os-u20-3262280-171-2:~# k apply -f luigi.yaml 
Warning: metadata.finalizers: "teardownPlugins": prefer a domain-qualified finalizer name to avoid accidental conflicts with other finalizer writers
networkplugins.plumber.k8s.pf9.io/networkplugins2-luigi created
```

Was able to delete it later on: 
```
root@test-pf9-qbert-bare-os-u20-3262280-171-2:~# k delete networkplugins networkplugins2-luigi
networkplugins.plumber.k8s.pf9.io "networkplugins2-luigi" deleted
```

Label applied to the hostplumber pod:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubectl.kubernetes.io/default-container: manager
  creationTimestamp: "2024-05-16T09:24:41Z"
  generateName: hostplumber-controller-manager-
  labels:
    control-plane: hostplumber-controller-manager
```

All pods running:
```
NAMESPACE                NAME                                                  READY   STATUS    RESTARTS      AGE
default                  whereabouts-dwj5m                                     1/1     Running   0             45s
default                  whereabouts-zpxt7                                     1/1     Running   0             45s
dhcp-controller-system   dhcp-controller-controller-manager-6ff6d57f9f-gqdlv   2/2     Running   0             45s
dhcp-controller-system   kubemacpool-cert-manager-7fd6d5c9c7-pqtsq             1/1     Running   0             44s
dhcp-controller-system   kubemacpool-mac-controller-manager-b4586cdcc-25l28    2/2     Running   0             44s
kube-system              calico-kube-controllers-6f89d5c87f-6jhch              1/1     Running   0             85m
kube-system              calico-node-tc87b                                     1/1     Running   0             85m
kube-system              calico-node-xf9zv                                     1/1     Running   0             85m
kube-system              calico-typha-autoscaler-6cc98c9474-wsmpg              1/1     Running   0             85m
kube-system              calico-typha-bf567dc9f-jvjjn                          1/1     Running   0             85m
kube-system              calico-typha-bf567dc9f-x8txj                          1/1     Running   0             84m
kube-system              coredns-7986ddc65c-9hcq5                              1/1     Running   0             82m
kube-system              coredns-7986ddc65c-jjxn5                              1/1     Running   0             82m
kube-system              k8s-master-10.149.106.45                              3/3     Running   0             83m
kube-system              kube-dns-autoscaler-557f6ffdbb-2hbrq                  1/1     Running   0             82m
kube-system              kube-state-metrics-565d86d4dd-vbht2                   1/1     Running   0             84m
kube-system              metrics-server-5b879dc669-jqf5r                       2/2     Running   0             82m
luigi-system             cert-manager-9dfd8cdc6-jk2sg                          1/1     Running   0             46m
luigi-system             cert-manager-cainjector-cc668794-vtj9c                1/1     Running   0             46m
luigi-system             cert-manager-webhook-68447b9c99-r9p2l                 1/1     Running   0             46m
luigi-system             hostplumber-controller-manager-gjkkq                  2/2     Running   0             45s
luigi-system             kube-multus-ds-amd64-qgsvg                            1/1     Running   0             45s
luigi-system             kube-multus-ds-amd64-zdtbk                            1/1     Running   0             45s
luigi-system             luigi-controller-manager-6f84b6588-w5wbn              2/2     Running   0             37m
luigi-system             ovs-cni-amd64-wjbm9                                   1/1     Running   2 (40s ago)   45s
luigi-system             ovs-daemons-25bhz                                     1/1     Running   0             45s
pf9-addons               pf9-addon-operator-67f84bf657-6jqzl                   1/1     Running   0             85m
```