### PR TITLE
Added ability to customize hostplumber metrics port

### DIFF
--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -61,7 +61,7 @@ const (
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5-2"
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.28.0"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.28.0"
-	HostPlumberImage        = "docker.io/manasab26/hostplumber:private-master-manasa-PMK-6484"
+	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.5.5"
 	DhcpControllerImage     = "docker.io/platform9/pf9-dhcp-controller:v1.1"
 	KubemacpoolImage        = "quay.io/kubevirt/kubemacpool:v0.41.0"
 	KubemacpoolRangeStart   = "02:55:43:00:00:00"

--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -61,7 +61,7 @@ const (
 	OvsImage                = "docker.io/platform9/openvswitch:v2.17.5-2"
 	OvsCniImage             = "quay.io/kubevirt/ovs-cni-plugin:v0.28.0"
 	OvsMarkerImage          = "quay.io/kubevirt/ovs-cni-marker:v0.28.0"
-	HostPlumberImage        = "docker.io/platform9/hostplumber:v0.5.5"
+	HostPlumberImage        = "docker.io/manasab26/hostplumber:private-master-manasa-PMK-6484"
 	DhcpControllerImage     = "docker.io/platform9/pf9-dhcp-controller:v1.1"
 	KubemacpoolImage        = "quay.io/kubevirt/kubemacpool:v0.41.0"
 	KubemacpoolRangeStart   = "02:55:43:00:00:00"

--- a/hostplumber/main.go
+++ b/hostplumber/main.go
@@ -53,35 +53,6 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
-func validateIPAddressPort(address string) error {
-
-	host, portStr, err := net.SplitHostPort(address)
-	if err != nil {
-		return fmt.Errorf("address must be in the format IP:port")
-	}
-
-	// Validate the IP part
-	parsedIP := net.ParseIP(host)
-	if parsedIP == nil {
-		return fmt.Errorf("invalid IP address")
-	}
-
-	if parsedIP.To4() == nil && parsedIP.To16() == nil {
-		return fmt.Errorf("metric bind address isn't ipv4 or ipv6 address")
-	}
-
-	// Validate the port part
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return fmt.Errorf("invalid port")
-	}
-	if port < 1 || port > 65535 {
-		return fmt.Errorf("port must be between 1 and 65535")
-	}
-
-	return nil
-}
-
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -101,12 +72,6 @@ func main() {
 
 	if os.Getenv("METRICS_BIND_ADDRESS") != "" {
 		metricsAddr = os.Getenv("METRICS_BIND_ADDRESS")
-	}
-
-	err := validateIPAddressPort(metricsAddr)
-	if err != nil {
-		setupLog.Error(err, "metrics bind address is invalid")
-		os.Exit(1)
 	}
 
 	nodeName := os.Getenv("K8S_NODE_NAME")

--- a/hostplumber/main.go
+++ b/hostplumber/main.go
@@ -68,6 +68,10 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	if os.Getenv("METRICS_BIND_ADDRESS") != "" {
+		metricsAddr = os.Getenv("METRICS_BIND_ADDRESS")
+	}
+
 	nodeName := os.Getenv("K8S_NODE_NAME")
 	if nodeName == "" {
 		fmt.Printf("K8S_NODE_NAME env variable not set")

--- a/plugin_templates/pf9-hostplumber/hostplumber.yaml
+++ b/plugin_templates/pf9-hostplumber/hostplumber.yaml
@@ -456,13 +456,12 @@ subjects:
 ---
 apiVersion: v1
 data:
+  METRICS_BIND_ADDRESS: 127.0.0.1:8080
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
     kind: ControllerManagerConfig
     health:
       healthProbeBindAddress: :8081
-    metrics:
-      bindAddress: 127.0.0.1:8080
     webhook:
       port: 9443
     leaderElection:
@@ -522,7 +521,6 @@ spec:
           protocol: TCP
       - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         command:
         - /manager
@@ -535,6 +533,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: METRICS_BIND_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              key: METRICS_BIND_ADDRESS
+              name: hostplumber-manager-config
+              optional: true
         image: {{ .HostPlumberImage }}
         imagePullPolicy: {{ .ImagePullPolicy }}
         livenessProbe:


### PR DESCRIPTION
## ISSUE(S):
[PMK-6484](https://platform9.atlassian.net/browse/PMK-6484)

## SUMMARY:
Added the ability to customize hostplumber metrics port by changing the value of `METRICS_BIND_ADDRESS` in `hostplumber-manager-config` configmap

## TESTING:

With these changes, built a new luigi and hostplumber image, and tested these images
Pods came up fine:
```
luigi-system           cert-manager-9dfd8cdc6-fkwnw                1/1     Running   0          5h7m
luigi-system           cert-manager-cainjector-cc668794-kkqtd      1/1     Running   0          5h7m
luigi-system           cert-manager-webhook-68447b9c99-47t7g       1/1     Running   0          5h7m
luigi-system           hostplumber-controller-manager-7ffjm        2/2     Running   0          69s
luigi-system           hostplumber-controller-manager-zxdrz        2/2     Running   0          68s
luigi-system           luigi-controller-manager-794f54794c-w4qbg   2/2     Running   0          2m16s
```
Events of `luigi-controller-manager-794f54794c-w4qbg` pod:
```
Events:
  Type    Reason     Age    From               Message
  ----    ------     ----   ----               -------
  Normal  Scheduled  4m26s  default-scheduler  Successfully assigned luigi-system/luigi-controller-manager-794f54794c-w4qbg to 10.149.106.212
  Normal  Pulled     4m26s  kubelet            Container image "gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0" already present on machine
  Normal  Created    4m26s  kubelet            Created container kube-rbac-proxy
  Normal  Started    4m26s  kubelet            Started container kube-rbac-proxy
  Normal  Pulled     4m26s  kubelet            Container image "docker.io/manasab26/luigi-plugins:private-master-manasa-PMK-6484-pmk-3299898" already present on machine
  Normal  Created    4m25s  kubelet            Created container manager
  Normal  Started    4m25s  kubelet            Started container manager
```
Events of `hostplumber-controller-manager-zxdrz` pod:
```
Events:
  Type    Reason     Age    From               Message
  ----    ------     ----   ----               -------
  Normal  Scheduled  2m28s  default-scheduler  Successfully assigned luigi-system/hostplumber-controller-manager-7ffjm to 10.149.106.63
  Normal  Pulled     2m28s  kubelet            Container image "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0" already present on machine
  Normal  Created    2m28s  kubelet            Created container kube-rbac-proxy
  Normal  Started    2m28s  kubelet            Started container kube-rbac-proxy
  Normal  Pulled     2m28s  kubelet            Container image "docker.io/manasab26/hostplumber:private-master-manasa-PMK-6484" already present on machine
  Normal  Created    2m28s  kubelet            Created container manager
  Normal  Started    2m28s  kubelet            Started container manager
```
Environment details in `describe` of one of the hostplumber-controller-manager pods
```
Environment:
      K8S_NODE_NAME:          (v1:spec.nodeName)
      K8S_NAMESPACE:         luigi-system (v1:metadata.namespace)
      METRICS_BIND_ADDRESS:  <set to the key 'METRICS_BIND_ADDRESS' of config map 'hostplumber-manager-config'>  Optional: true
```
Daemonset:
```
kc get ds hostplumber-controller-manager -n luigi-system -o yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  annotations:
    deprecated.daemonset.template.generation: "1"
  creationTimestamp: "2024-07-01T13:33:35Z"
  generation: 1
  labels:
    control-plane: controller-manager
  name: hostplumber-controller-manager
...
        - name: K8S_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
        - name: METRICS_BIND_ADDRESS
          valueFrom:
            configMapKeyRef:
              key: METRICS_BIND_ADDRESS
              name: hostplumber-manager-config
              optional: true
```
`hostplumber-manager-config` cm:
```
kc get cm hostplumber-manager-config  -o yaml -n luigi-system
apiVersion: v1
data:
  METRICS_BIND_ADDRESS: 127.0.0.1:8080
  controller_manager_config.yaml: |
    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
    kind: ControllerManagerConfig
    health:
      healthProbeBindAddress: :8081
    webhook:
      port: 9443
    leaderElection:
      leaderElect: true
      resourceName: 52f205ce.k8s.pf9.io
kind: ConfigMap
metadata:
  creationTimestamp: "2024-07-01T13:00:40Z"
  name: hostplumber-manager-config
  namespace: luigi-system
  resourceVersion: "48979"
  uid: 71cd7bcd-6065-4241-8d5c-ceef8488c3db
```

Changed METRICS_BIND_ADDRESS to `127.0.0.1:8085`
```
apiVersion: v1
data:
  METRICS_BIND_ADDRESS: 127.0.0.1:8085
  controller_manager_config.yaml: |
    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
    kind: ControllerManagerConfig
```
Deleted the hostplumber-controller-manager pods after making this configMap change, then when new pods came up, checked their logs

Logs of`hostplumber-controller-manager-zxdrz` pod:

``` kc logs -n luigi-system           hostplumber-controller-manager-zxdrz
2024-07-01T13:34:16Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "127.0.0.1:8085"}
2024-07-01T13:34:16Z	INFO	setup	starting manager
2024-07-01T13:34:16Z	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "127.0.0.1:8085"}
2024-07-01T13:34:16Z	INFO	Starting server	{"kind": "health probe", "addr": "[::]:8081"}
2024-07-01T13:34:16Z	INFO	Starting EventSource	{"controller": "hostnetworktemplate", "controllerGroup": "plumber.k8s.pf9.io", "controllerKind": "HostNetworkTemplate", "source": "kind source: *v1.HostNetworkTemplate"}
2024-07-01T13:34:16Z	INFO	Starting Controller	{"controller": "hostnetworktemplate", "controllerGroup": "plumber.k8s.pf9.io", "controllerKind": "HostNetworkTemplate"}
2024-07-01T13:34:16Z	INFO	Starting workers	{"controller": "hostnetworktemplate", "controllerGroup": "plumber.k8s.pf9.io", "controllerKind": "HostNetworkTemplate", "worker count": 1}
```
Could see that it's now using newer metric-bind-address, as provided in configmap

[PMK-6484]: https://platform9.atlassian.net/browse/PMK-6484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ