### PR TITLE
[Backport for PMK 5.10] Added ability to customize hostplumber metrics port 

### DIFF
--- a/hostplumber/main.go
+++ b/hostplumber/main.go
@@ -19,9 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net"
 	"os"
-	"strconv"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)

--- a/hostplumber/main.go
+++ b/hostplumber/main.go
@@ -19,7 +19,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -67,6 +69,10 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if os.Getenv("METRICS_BIND_ADDRESS") != "" {
+		metricsAddr = os.Getenv("METRICS_BIND_ADDRESS")
+	}
 
 	nodeName := os.Getenv("K8S_NODE_NAME")
 	if nodeName == "" {

--- a/plugin_templates/pf9-hostplumber/hostplumber.yaml
+++ b/plugin_templates/pf9-hostplumber/hostplumber.yaml
@@ -456,13 +456,12 @@ subjects:
 ---
 apiVersion: v1
 data:
+  METRICS_BIND_ADDRESS: 127.0.0.1:8080
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
     kind: ControllerManagerConfig
     health:
       healthProbeBindAddress: :8081
-    metrics:
-      bindAddress: 127.0.0.1:8080
     webhook:
       port: 9443
     leaderElection:
@@ -522,7 +521,6 @@ spec:
           protocol: TCP
       - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         command:
         - /manager
@@ -535,6 +533,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: METRICS_BIND_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              key: METRICS_BIND_ADDRESS
+              name: hostplumber-manager-config
+              optional: true
         image: {{ .HostPlumberImage }}
         imagePullPolicy: {{ .ImagePullPolicy }}
         livenessProbe:


### PR DESCRIPTION
Backporting the fix: https://github.com/platform9/luigi/pull/211 to v0.5.6 branch