### PR TITLE
Added metricsPort to hostplumber plugin

### DIFF
--- a/api/v1/networkplugins_types.go
+++ b/api/v1/networkplugins_types.go
@@ -68,6 +68,7 @@ type HostPlumber struct {
 	Namespace        string `json:"namespace,omitempty"`
 	ImagePullPolicy  string `json:"imagePullPolicy,omitempty"`
 	HostPlumberImage string `json:"hostPlumberImage,omitempty"`
+	MetricsPort      string `json:"metricsPort,omitempty"`
 }
 
 type Whereabouts struct {

--- a/config/crd/bases/plumber.k8s.pf9.io_networkplugins.yaml
+++ b/config/crd/bases/plumber.k8s.pf9.io_networkplugins.yaml
@@ -58,6 +58,8 @@ spec:
                         type: string
                       namespace:
                         type: string
+                      metricsPort:
+                        type: string
                     type: object
                   multus:
                     properties:

--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -54,6 +54,7 @@ import (
 const (
 	DefaultNamespace        = "luigi-system"
 	KubemacpoolNamespace    = "dhcp-controller-system"
+	DefaultMetricsPort      = "8080"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2644970"
 	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6.3-pmk-3299438"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2877848"
@@ -224,7 +225,7 @@ func (hostPlumberConfig *HostPlumberT) WriteConfigToTemplate(outputDir, registry
 	if hostPlumberConfig.MetricsPort != "" {
 		config["MetricsPort"] = hostPlumberConfig.MetricsPort
 	} else {
-		config["MetricsPort"] = "8080"
+		config["MetricsPort"] = DefaultMetricsPort
 	}
 
 	config["KubeRbacProxyImage"] = ReplaceContainerRegistry(KubeRbacProxyImage, registry)

--- a/controllers/networkplugins_controller.go
+++ b/controllers/networkplugins_controller.go
@@ -221,6 +221,12 @@ func (hostPlumberConfig *HostPlumberT) WriteConfigToTemplate(outputDir, registry
 		config["HostPlumberImage"] = ReplaceContainerRegistry(HostPlumberImage, registry)
 	}
 
+	if hostPlumberConfig.MetricsPort != "" {
+		config["MetricsPort"] = hostPlumberConfig.MetricsPort
+	} else {
+		config["MetricsPort"] = "8080"
+	}
+
 	config["KubeRbacProxyImage"] = ReplaceContainerRegistry(KubeRbacProxyImage, registry)
 
 	t, err := template.ParseFiles(filepath.Join(TemplateDir, "pf9-hostplumber", "hostplumber.yaml"))

--- a/kustomize_luigi.yaml
+++ b/kustomize_luigi.yaml
@@ -51,6 +51,8 @@ spec:
                         type: string
                       namespace:
                         type: string
+                      metricsPort:
+                        type: string
                     type: object
                   multus:
                     properties:

--- a/plugin_templates/pf9-hostplumber/hostplumber.yaml
+++ b/plugin_templates/pf9-hostplumber/hostplumber.yaml
@@ -456,7 +456,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  METRICS_BIND_ADDRESS: 127.0.0.1:8080
+  METRICS_BIND_ADDRESS: 127.0.0.1:{{ .MetricsPort }}
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
     kind: ControllerManagerConfig

--- a/v2/api/v1/networkplugins_types.go
+++ b/v2/api/v1/networkplugins_types.go
@@ -59,6 +59,7 @@ type HostPlumber struct {
 	Namespace        string `json:"namespace,omitempty"`
 	ImagePullPolicy  string `json:"imagePullPolicy,omitempty"`
 	HostPlumberImage string `json:"hostPlumberImage,omitempty"`
+	MetricsPort      string `json:"metricsPort,omitempty"`
 }
 
 type Whereabouts struct {

--- a/v2/controllers/networkplugins_controller.go
+++ b/v2/controllers/networkplugins_controller.go
@@ -198,6 +198,12 @@ func (hostPlumberConfig *HostPlumberT) WriteConfigToTemplate(outputDir, registry
 		config["HostPlumberImage"] = ReplaceContainerRegistry(HostPlumberImage, registry)
 	}
 
+	if hostPlumberConfig.MetricsPort != "" {
+		config["MetricsPort"] = hostPlumberConfig.MetricsPort
+	} else {
+		config["MetricsPort"] = "8080"
+	}
+	
 	config["KubeRbacProxyImage"] = ReplaceContainerRegistry(KubeRbacProxyImage, registry)
 
 	t, err := template.ParseFiles(filepath.Join(TemplateDir, "pf9-hostplumber", "hostplumber.yaml"))

--- a/v2/controllers/networkplugins_controller.go
+++ b/v2/controllers/networkplugins_controller.go
@@ -47,6 +47,7 @@ import (
 
 const (
 	DefaultNamespace        = "default"
+	DefaultMetricsPort      = "8080"
 	MultusImage             = "docker.io/platform9/multus:v3.7.2-pmk-2573338"
 	WhereaboutsImage        = "docker.io/platform9/whereabouts:v0.6-pmk-2754876"
 	SriovCniImage           = "docker.io/platform9/sriov-cni:v2.6.2-pmk-2877848"
@@ -201,9 +202,9 @@ func (hostPlumberConfig *HostPlumberT) WriteConfigToTemplate(outputDir, registry
 	if hostPlumberConfig.MetricsPort != "" {
 		config["MetricsPort"] = hostPlumberConfig.MetricsPort
 	} else {
-		config["MetricsPort"] = "8080"
+		config["MetricsPort"] = DefaultMetricsPort
 	}
-	
+
 	config["KubeRbacProxyImage"] = ReplaceContainerRegistry(KubeRbacProxyImage, registry)
 
 	t, err := template.ParseFiles(filepath.Join(TemplateDir, "pf9-hostplumber", "hostplumber.yaml"))


### PR DESCRIPTION
This PR solves [PMK-6532](https://platform9.atlassian.net/browse/PMK-6532) 

So, Previous solution was not persisting over the upgrades. This solution will require you to provide metricsPort as a part of networkplugins.yaml. Example of the file:

```
apiVersion: plumber.k8s.pf9.io/v1
kind: NetworkPlugins
metadata:
  name: networkplugins-sample-nosriov
spec:
  # Add fields here
  #privateRegistryBase: "localhost:5100"
  plugins:
    hostPlumber:
      metricsPort: "8090"
      namespace: default
    nodeFeatureDiscovery:
      namespace: default
    multus:
      namespace: default
    whereabouts:
      namespace: default
      ipReconcilerSchedule: "* * * * *"
    #sriov: {}
    #ovs: {}

```

Testing: Tested this on a DU and the change persisted over the upgrade from 1.28 to 1.29. Attaching the snippet of hostplumber CM:

```
apiVersion: v1
data:
  METRICS_BIND_ADDRESS: 127.0.0.1:8090
  controller_manager_config.yaml: |
    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
    kind: ControllerManagerConfig
    health:
      healthProbeBindAddress: :8081
    webhook:
      port: 9443
    leaderElection:
      leaderElect: true
      resourceName: 52f205ce.k8s.pf9.io
kind: ConfigMap
metadata:
  creationTimestamp: "2024-08-13T12:05:49Z"
  name: hostplumber-manager-config
  namespace: default
  resourceVersion: "5972"
  uid: 3fb2c295-c29f-4902-b3aa-79bacf80f528
  ```

[PMK-6532]: https://platform9.atlassian.net/browse/PMK-6532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ