### PR TITLE
Update sampleplugins.yaml

### DIFF
--- a/samples/sampleplugins.yaml
+++ b/samples/sampleplugins.yaml
@@ -7,7 +7,7 @@ spec:
   #privateRegistryBase: "localhost:5100"
   plugins:
     hostPlumber:
-      # Optionally, customise the metrics bind address
+      # Optionally, customise the metrics server bind address (port)
       metricsPort: "8090"
       # Must be preceded by `kubectl create namespace hostplumber`
       # Hostplumber can be deployed in its own namespace to avoid webhook conflict with Luigi

--- a/samples/sampleplugins.yaml
+++ b/samples/sampleplugins.yaml
@@ -6,8 +6,11 @@ spec:
   # Add fields here
   #privateRegistryBase: "localhost:5100"
   plugins:
-    # Must be preceded by `kubectl create namespace hostplumber`
-    hostPlumber: 
+    hostPlumber:
+      # Optionally, customise the metrics bind address
+      metricsPort: "8090"
+      # Must be preceded by `kubectl create namespace hostplumber`
+      # Hostplumber can be deployed in its own namespace to avoid webhook conflict with Luigi
       namespace: hostplumber
     nodeFeatureDiscovery: {}
     multus: {}


### PR DESCRIPTION
Updated the sample hostplumber configuration to demonstrate how to customise the metrics bind address (fixed in https://github.com/platform9/luigi/pull/230#issue-2463231959)
Refer : Fixed in [PMK-6484](https://platform9.atlassian.net/browse/PMK-6484) , follow-up fix to make the customisation persist [PMK-6532](https://platform9.atlassian.net/browse/PMK-6532)

[PMK-6484]: https://platform9.atlassian.net/browse/PMK-6484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PMK-6532]: https://platform9.atlassian.net/browse/PMK-6532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ