### PR TITLE
Build luigi, openvswitch images via github action 

### DIFF
--- a/.github/workflows/luigi-build-and-push.yml
+++ b/.github/workflows/luigi-build-and-push.yml
@@ -1,0 +1,39 @@
+---
+name: docker
+on:
+  push:
+    branches:
+      - 'master'
+      - 'v*'
+      - 'private/**'
+
+jobs:
+  buildx:
+    env:
+      USERNAME: ${{ secrets.QUAY_USERNAME }}
+      PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Docker BuildX
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      # setup Docker buld action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to the Quay Registry
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ env.USERNAME }}
+          password: ${{ env.PASSWORD }}
+
+      - name: Build/Push image to Quay Container Registry
+        run:
+          TEAMCITY_BUILD_ID=${{ github.run_number }}
+          make img-build-push        

--- a/.github/workflows/ovs-build-and-push.yml
+++ b/.github/workflows/ovs-build-and-push.yml
@@ -1,0 +1,53 @@
+---
+name: docker
+on:
+  push:
+    branches:
+      - 'master'
+      - 'v*'
+      - 'private/**'
+    paths:
+      - hostplumber/**
+
+jobs:
+  buildx:
+    env:
+      USERNAME: ${{ secrets.QUAY_USERNAME }}
+      PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      BUILD_ARGS: ""
+      PLATFORMS: linux/amd64
+      BRANCH: ${{ github.head_ref || github.ref_name }}
+      PUSH: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env
+        run: 
+          echo "TAG=$(echo "${{ env.BRANCH }}" | tr -d /)" >> $GITHUB_ENV
+         
+      - uses: actions/checkout@v3
+
+      - name: Setup Docker BuildX
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      # setup Docker buld action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to the Quay Registry
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ env.USERNAME }}
+          password: ${{ env.PASSWORD }}
+
+      - name: Build/Push image to Quay Container Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: hostplumber/pkg/ovs-docker
+          tags: quay.io/platform9/openvswitch:${{ env.TAG }}-${{ github.run_number }}
+          push: ${{ env.PUSH }}
+          build-args: ${{ env.BUILD_ARGS}}
+          platforms: ${{ env.PLATFORMS }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 # Image URL to use all building/pushing image targets
 #IMG ?= controller:latest
 VER_LABEL=$(shell ./get-label.bash)
-IMG ?= platform9/luigi-plugins:$(VER_LABEL)
+IMG ?= quay.io/platform9/luigi-plugins:$(VER_LABEL)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.27
 
@@ -154,7 +154,6 @@ img-build: $(BUILD_DIR) img-test
 	echo ${IMG} > $(BUILD_DIR)/container-tag
 
 img-build-push: img-build
-	docker login
 	docker push ${IMG}
 	echo ${IMG} > $(BUILD_DIR)/container-tag
 

--- a/hostplumber/pkg/ovs-docker/Dockerfile
+++ b/hostplumber/pkg/ovs-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.16
 
 RUN apk update && apk upgrade
 RUN apk add --no-cache bash


### PR DESCRIPTION
Image built via TC fails on certain hardware with core dumped error.
Building image via GitHub action with runs on : ubuntu-latest.

I have validated the image on the hardware it was failing on.
JIRA: https://platform9.atlassian.net/browse/PMK-6478

GitHub action triggers docker build and pushes images to dockerhub 