### PR TITLE
Update golang to 1.23 for Luigi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 img-test:
-	docker run --rm  -v $(SRCROOT):/luigi -w /luigi golang:1.22  bash -c "GOFLAGS=-buildvcs=false make test"
+	docker run --rm  -v $(SRCROOT):/luigi -w /luigi golang:1.23  bash -c "GOFLAGS=-buildvcs=false make test"
 
 img-build: $(BUILD_DIR) img-test 
 	docker build --network host . -t ${IMG}

--- a/dhcp-controller/Dockerfile
+++ b/dhcp-controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/dhcp-controller/dhcpserver/Dockerfile
+++ b/dhcp-controller/dhcpserver/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/dhcp-controller/dhcpserver/go.mod
+++ b/dhcp-controller/dhcpserver/go.mod
@@ -1,6 +1,6 @@
 module dhcpserver
 
-go 1.21
+go 1.23
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0

--- a/dhcp-controller/go.mod
+++ b/dhcp-controller/go.mod
@@ -1,6 +1,6 @@
 module dhcp-controller
 
-go 1.21
+go 1.23
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/platform9/luigi
 
-go 1.22.0
+go 1.23
 
-toolchain go1.22.7
+toolchain go1.23.3
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/hostplumber/Dockerfile
+++ b/hostplumber/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/hostplumber/Makefile
+++ b/hostplumber/Makefile
@@ -154,7 +154,7 @@ $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 img-test:
-	docker run --rm  -v $(SRCROOT):/hostplumber -w /hostplumber golang:1.22  bash -c "make test"
+	docker run --rm  -v $(SRCROOT):/hostplumber -w /hostplumber golang:1.23  bash -c "make test"
 
 img-build: $(BUILD_DIR) img-test 
 	docker build --network host . -t ${IMG}

--- a/hostplumber/go.mod
+++ b/hostplumber/go.mod
@@ -1,8 +1,8 @@
 module hostplumber
 
-go 1.22.0
+go 1.23
 
-toolchain go1.22.7
+toolchain go1.23.3
 
 require github.com/vishvananda/netlink v1.1.0
 

--- a/yoshi/Dockerfile
+++ b/yoshi/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/yoshi/go.mod
+++ b/yoshi/go.mod
@@ -1,8 +1,8 @@
 module github.com/platform9/luigi/yoshi
 
-go 1.22
+go 1.23
 
-toolchain go1.22.7
+toolchain go1.23.3
 
 require (
 	github.com/go-logr/logr v1.3.0


### PR DESCRIPTION
`make img-test` was failing since latest of setup-envtest requires golang 1.23

Luigi image built by GitHub action : `private-master-trilok-update_go_1.23-pmk-33`