### PR TITLE
[PMK-6907][CVE-2025-68121] Upgrade go from 1.23 to 1.26 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          go-version: 1.22
+          go-version: 1.24
           check-latest: true
           cache: true
       - name: Print the version of golang
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          go-version: 1.22
+          go-version: 1.24
           check-latest: true
           cache: true
       - name: Print the version of golang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          go-version: 1.24
+          go-version: 1.26
           check-latest: true
           cache: true
       - name: Print the version of golang
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          go-version: 1.24
+          go-version: 1.26
           check-latest: true
           cache: true
       - name: Print the version of golang

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 img-test:
-	docker run --rm  -v $(SRCROOT):/luigi -w /luigi golang:1.24  bash -c "GOFLAGS=-buildvcs=false make test"
+	docker run --rm  -v $(SRCROOT):/luigi -w /luigi golang:1.26  bash -c "GOFLAGS=-buildvcs=false make test"
 
 img-build: $(BUILD_DIR) img-test 
 	docker build --network host . -t ${IMG}

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 img-test:
-	docker run --rm  -v $(SRCROOT):/luigi -w /luigi golang:1.23  bash -c "GOFLAGS=-buildvcs=false make test"
+	docker run --rm  -v $(SRCROOT):/luigi -w /luigi golang:1.24  bash -c "GOFLAGS=-buildvcs=false make test"
 
 img-build: $(BUILD_DIR) img-test 
 	docker build --network host . -t ${IMG}

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.16.3
+CONTROLLER_TOOLS_VERSION ?= v0.17.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/platform9/luigi
 
-go 1.24
+go 1.26
 
-toolchain go1.24.13
+toolchain go1.26.0
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/platform9/luigi
 
-go 1.23
+go 1.24
 
-toolchain go1.23.3
+toolchain go1.24.13
 
 require (
 	github.com/dustin/go-humanize v1.0.1


### PR DESCRIPTION
## Fix Security Vulnerability
[https://github.com/platform9/luigi/security/code-scanning/106](https://github.com/platform9/luigi/security/code-scanning/106)

## Fix
The crypto/tls fix is part of the Go stdlib, so upgrading the Go toolchain itself (not a dependency) is the correct remediation. 
Go version upgrade from 1.23 to 1.26 .

## Testing
**Manual**
```
➜  ~ git:(main) ✗ k get pods -n luigi-system                                                                            
NAME                                        READY   STATUS    RESTARTS   AGE
cert-manager-775656cd8c-dpjkx               1/1     Running   0          3h12m
cert-manager-cainjector-7b4fc5b89-5vdpf     1/1     Running   0          3h12m
cert-manager-webhook-6b4c7f6888-4gvld       1/1     Running   0          3h12m
luigi-controller-manager-79ddbdc98d-zszz5   2/2     Running   0          2m46s
➜  ~ git:(main) ✗ 
➜  ~ git:(main) ✗ k get pods -n luigi-system luigi-controller-manager-79ddbdc98d-zszz5  -oyaml | grep image | grep luigi
    image: quay.io/platform9/luigi-plugins:private-snh-fix_code_scan-pmk-4767864
    image: quay.io/platform9/luigi-plugins:private-snh-fix_code_scan-pmk-4767864
    imageID: quay.io/platform9/luigi-plugins@sha256:9f3447e7000486d6a6153ec0cb35490357f1c6990dac7f414cc9dd148dc231e6
```